### PR TITLE
ci: remove charmstore credentials and update repository list

### DIFF
--- a/.github/workflows/sync_charmstore_credentials.yaml
+++ b/.github/workflows/sync_charmstore_credentials.yaml
@@ -15,19 +15,17 @@ jobs:
       - uses: google/secrets-sync-action@v1.5.0
         with:
           SECRETS: |
-            ^CHARMSTORE_CREDENTIAL$
             ^CHARMCRAFT_CREDENTIALS$
           REPOSITORIES: |
             ^canonical/admission-webhook-operator$
             ^canonical/argo-operators$
             ^canonical/bundle-cert-manager$
             ^canonical/bundle-kubeflow$
-            ^canonical/charm-tf-serving$
             ^canonical/dex-auth-operator$
             ^canonical/envoy-operator$
             ^canonical/istio-operators$
             ^canonical/kfp-operators$
-            ^canonical/kfserving-operator$
+            ^canonical/kserve-operators$
             ^canonical/kubeflow-dashboard-operator$
             ^canonical/kubeflow-profiles-operator$
             ^canonical/kubeflow-roles-operator
@@ -47,5 +45,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           CONCURRENCY: 10
         env:
-          CHARMSTORE_CREDENTIAL: ${{ secrets.CHARMSTORE_CREDENTIAL }}
           CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}


### PR DESCRIPTION
This PR introduces the following:
* Remove charmstore secret as all the charms currently maintained by the Kubeflow team are in charmhub.
* Update and remove repository names to match our list of active repos
